### PR TITLE
Migrating to Express 4

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,11 +5,15 @@
  * richard@codezuki.com
  */
 
-var express = require('express'),
+var bodyParser = require('body-parser'),
+    cookieParser = require('cookie-parser'),
+    cookieSession = require('cookie-session'),
+    express = require('express'),
     routes = require('./routes'),
     shopifyAuth = require('./routes/shopify_auth'),
     path = require('path'),
-    nconf = require('nconf');
+    nconf = require('nconf'),
+    morgan = require('morgan');
 
 //load settings from environment config
 nconf.argv().env().file({
@@ -21,15 +25,15 @@ exports.nconf = nconf;
 var app = express();
 
 //log all requests
-app.use(express.logger());
+app.use(morgan('combined'));
 
 //support json and url encoded requests
-app.use(express.json());
-app.use(express.urlencoded());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: false }));
 
 //setup encrypted session cookies
-app.use(express.cookieParser());
-app.use(express.session({
+app.use(cookieParser());
+app.use(cookieSession({
     secret: "--express-session-encryption-key--"
 }));
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,13 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "3.4.8",
+    "body-parser": "~1.14.0",
+    "cookie-parser": "~1.4.0",
+    "cookie-session": "~1.2.0",
+    "express": "~4.13.3",
     "jade": "*",
-    "oauth": "~0.9.11",
-    "nconf": "~0.6.9"
+    "oauth": "~0.9.14",
+    "nconf": "~0.8.0",
+    "morgan": "~1.6.1"
   }
 }


### PR DESCRIPTION
Replaced modules according to recommended replacements at http://expressjs.com/guide/migrating-4.html.
